### PR TITLE
[Discussion] Demonstrate failing test for camel <> underscore conversion

### DIFF
--- a/test_inflection.py
+++ b/test_inflection.py
@@ -112,7 +112,7 @@ CAMEL_TO_UNDERSCORE = (
     ("Product",               "product"),
     ("SpecialGuest",          "special_guest"),
     ("ApplicationController", "application_controller"),
-    ("Area51Controller",      "area51_controller"),
+    ("Area51Controller",      "area_51_controller"),
 )
 
 CAMEL_TO_UNDERSCORE_WITHOUT_REVERSE = (


### PR DESCRIPTION
These tests do not agree: [underscore to camel conversion](https://github.com/jpvanhal/inflection/blob/master/test_inflection.py#L317-L318) and [camel to underscore conversion](https://github.com/jpvanhal/inflection/blob/master/test_inflection.py#L332-L333)

If I'm reading correctly they use the same data and changing area51_controller Iike I did should cause two tests to fail but only one test fails. This means that words with numbers can only be converted one way: `address_1` will go `address1` but `address1` will not go back to `address_1`. I suggest using numbers as boundaries so that Area51Controller becomes area_51_controller. Thoughts?

Related issue https://github.com/ngenworks/rest_framework_ember/issues/22