### PR TITLE
Fix incorrect pluralisation of 'human' - add human/humans to tests

### DIFF
--- a/inflection.py
+++ b/inflection.py
@@ -415,6 +415,7 @@ def underscore(word):
 
 _irregular('person', 'people')
 _irregular('man', 'men')
+_irregular('human', 'humans')
 _irregular('child', 'children')
 _irregular('sex', 'sexes')
 _irregular('move', 'moves')

--- a/test_inflection.py
+++ b/test_inflection.py
@@ -106,6 +106,7 @@ SINGULAR_TO_PLURAL = (
 
     ("cow", "kine"),
     ("database", "databases"),
+    ("human", "humans")
 )
 
 CAMEL_TO_UNDERSCORE = (


### PR DESCRIPTION
Hi,

I ran into this today.  Human is incorrectly pluralised as 'humen' - I checked and this error also exists in the rails implementation.

The simplest fix seems to be to call irregular after the rule for man/men has been added.