### PR TITLE
Include docs in releases

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.rst LICENSE CHANGES.rst test_inflection.py
-
+recursive-include docs *


### PR DESCRIPTION
Hi, could you add the docs to PyPI for easier packaging? Gentoo, for instance, relies on PyPI tarballs to build docs.