### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Inflection is a port of `Ruby on Rails`_' `inflector`_ to Python.
 Resources
 ---------
 
-- `Documentation <http://inflection.readthedocs.org/>`_
+- `Documentation <https://inflection.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/jpvanhal/inflection/issues>`_
 - `Code <http://github.com/jpvanhal/inflection>`_
 - `Development Version


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.