### PR TITLE
Fix linter error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - pypy
   - 3.3

--- a/inflection.py
+++ b/inflection.py
@@ -149,8 +149,8 @@ def camelize(string, uppercase_first_letter=True):
         >>> camelize("device_type", False)
         "deviceType"
 
-    :func:`camelize` can be thought of as a inverse of :func:`underscore`, although
-    there are some cases where that does not hold::
+    :func:`camelize` can be thought of as a inverse of :func:`underscore`,
+    although there are some cases where that does not hold::
 
         >>> camelize(underscore("IOError"))
         "IoError"


### PR DESCRIPTION
Fix linter error being thrown on Travis. This should change the build badge to "passing" rather than showing the current "failing" badge that would be putting off users.

I also suggest you drop python 2.6 as this is failing to run flake8. This is because is not supported by the core team anymore.

@jpvanhal 