### PR TITLE
Update versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 python:
   - 2.7
   - pypy
-  - 3.3
   - 3.4
+  - 3.5
+  - 3.6
 script:
   - flake8 .
   - isort --recursive --diff . && isort --recursive --check-only .
-  - py.test
+  - pytest

--- a/inflection.py
+++ b/inflection.py
@@ -74,7 +74,7 @@ SINGULARS = [
     (r"(?i)s$", ''),
 ]
 
-UNCOUNTABLES = set([
+UNCOUNTABLES = {
     'equipment',
     'fish',
     'information',
@@ -83,8 +83,7 @@ UNCOUNTABLES = set([
     'rice',
     'series',
     'sheep',
-    'species',
-])
+    'species'}
 
 
 def _irregular(singular, plural):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     license='MIT',
     py_modules=['inflection'],
     zip_safe=False,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -26,11 +27,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/test_inflection.py
+++ b/test_inflection.py
@@ -327,8 +327,8 @@ def test_singularize_plural(singular, plural):
 
 @pytest.mark.parametrize(("singular", "plural"), SINGULAR_TO_PLURAL)
 def test_pluralize_plural(singular, plural):
-    assert plural == inflection.pluralize(plural)
-    assert plural.capitalize() == inflection.pluralize(plural.capitalize())
+    assert plural == inflection.pluralize(singular)
+    assert plural.capitalize() == inflection.pluralize(singular.capitalize())
 
 
 @pytest.mark.parametrize(("before", "titleized"), MIXTURE_TO_TITLEIZED)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34
+envlist = py27, pypy, py34, py35, py36
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Python 2.6 and 3.3 are both EOL and no longer receiving security updates from the core team. 

2.6 was already dropped in https://github.com/jpvanhal/inflection/pull/20.

Also add 3.5 and 3.6.

Also replace function call with set literal, and fix a test that looks like it had a copy/paste mistake.