### PR TITLE
Comment out unused html_static_path from doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ html_theme = 'default' if on_rtd else 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
To avoid the following warning:
WARNING: html_static_path entry '_static' does not exist