### PR TITLE
add 'diabetes' to UNCOUNTABLES

### DIFF
--- a/inflection/__init__.py
+++ b/inflection/__init__.py
@@ -85,7 +85,8 @@ UNCOUNTABLES = {
     'rice',
     'series',
     'sheep',
-    'species'}
+    'species',
+    'diabetes'}
 
 
 def _irregular(singular: str, plural: str) -> None:


### PR DESCRIPTION
'diabetes' is treated as a plural form. and changes the word to 'diabete'.