### PR TITLE
fix: add py.typed to SDist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst LICENSE test_inflection.py
-graft inflection
+recursive-include inflection py.typed
 graft docs
 prune docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst LICENSE test_inflection.py
+graft inflection
 graft docs
 prune docs/_build


### PR DESCRIPTION
See [comment](https://github.com/jpvanhal/inflection/issues/44#issuecomment-750732596) on #44.

Missing from the SDist, and therefore the wheel. So any usage of MyPy downstream looks like this currently:

```
...:8: error: Cannot find implementation or library stub for module named 'inflection'
...:8: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```